### PR TITLE
fix: Build issues

### DIFF
--- a/src/404.md
+++ b/src/404.md
@@ -1,9 +1,0 @@
----
-title: 'Not Found'
-layout: page.html
-permalink: /404.html
----
-
-404 Not Found
-
-<a href="/">Go Home</a>


### PR DESCRIPTION
There was a syntax error in the 404 page after changing the extension of the `page.njk` template. The 404 page hasn't been fully implemented yet, so removing it for the time being.